### PR TITLE
Respond to OPTIONS requests with CORS headers to allow preflighted requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,14 @@ function enableCors (req, res, next) {
   res.header("Access-Control-Allow-Origin", "*")
   res.header('Access-Control-Allow-Methods', 'POST')
   res.header("Access-Control-Allow-Headers", "X-Requested-With")
-  if (req.method === "OPTIONS") return res.send(200)
   next()
+}
+
+function optionsHandler(methods) {
+  return function(req, res, next) {
+    res.header('Allow', methods)
+    res.send(methods)
+  }
 }
 
 exports.createServer = function (opts) {
@@ -31,6 +37,7 @@ exports.createServer = function (opts) {
 
   app.get('/', function (req, res) { res.render('home', { trackcode: opts.gaCode || '' }) })
 
+  app.options('/convert', enableCors, optionsHandler('POST'))
   app.post('/convert', enableCors, function (req, res, next) {
     var ogr = ogr2ogr(req.files.upload.path)
 
@@ -54,6 +61,7 @@ exports.createServer = function (opts) {
     })
   })
 
+  app.options('/convertJson', enableCors, optionsHandler('POST'))
   app.post('/convertJson', enableCors, function (req, res, next) {
     if (!req.body.jsonUrl && !req.body.json) return next(new Error('No json provided'))
 

--- a/test/api.js
+++ b/test/api.js
@@ -45,6 +45,15 @@ test('convert', function (t) {
     .end(function (er, res) {
       t.notOk(er, 'no error', { error: er })
     })
+
+  request(server)
+    .options('/convert')
+    .expect('Access-Control-Allow-Origin', '*')
+    .expect('Access-Control-Allow-Methods', 'POST')
+    .expect('Access-Control-Allow-Headers', 'X-Requested-With')
+    .expect('Allow', 'POST')
+    .expect('Content-Type', 'text/html; charset=utf-8')
+    .expect('POST')
 })
 
 test('convertJson', function (t) {
@@ -59,6 +68,15 @@ test('convertJson', function (t) {
       t.equal(buf[0], 'P', 'is zip')
       t.end()
     })
+
+  request(server)
+    .options('/convertJson')
+    .expect('Access-Control-Allow-Origin', '*')
+    .expect('Access-Control-Allow-Methods', 'POST')
+    .expect('Access-Control-Allow-Headers', 'X-Requested-With')
+    .expect('Allow', 'POST')
+    .expect('Content-Type', 'text/html; charset=utf-8')
+    .expect('POST')
 })
 
 test('close server', function (t) {


### PR DESCRIPTION
Browsers may preflight CORS requests by issuing OPTIONS requests.  They will refuse to perform the request if they don't see the CORS headers.  See: https://developer.mozilla.org/en-US/docs/HTTP/Access_control_CORS#Preflighted_requests

In Ogre, Express is using the default OPTIONS handler, bypassing the CORS code.  `curl -XOPTIONS -v 'http://ogre.adc4gis.com/convert'` demonstrates that no 'Access-Control-*' headers are being returned.

This pull request updates Ogre to respond to OPTIONS on /convert and /convertJson by returning CORS headers.  It sets the "Allow" header and response body to "POST" to remain compatible with the current (default) behavior.
