### PR TITLE
Adding responseType parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,13 @@ exports.createServer = function (opts) {
     res.on('end', function () { fs.unlink(req.files.upload.path) })
 
     if (!req.body.callback) {
-      res.header('Content-Type', 'forcePlainText' in req.body ? 'text/plain; charset=utf-8' : 'application/json; charset=utf-8')
+	  if (req.body.responseType && req.body.responseType == "download"){
+	    res.header('Content-Type', 'forcePlainText' in req.body ? 'text/plain; charset=utf-8' : 'application/octet-stream; charset=utf-8')
+	    res.header('Content-Disposition', 'attachment; filename='+req.files.upload.originalFilename+'.geojson')
+	  }else{
+	    // standard JSON response
+	    res.header('Content-Type', 'forcePlainText' in req.body ? 'text/plain; charset=utf-8' : 'application/json; charset=utf-8')
+	  }
       return sf.pipe(res)
     }
 


### PR DESCRIPTION
In POST parameter, if "responseType" is not set = standard "application/json" response.
If it is set to "download" the response is "application/octet-stream" to force webbrowser to download the GeoJson (output file name is based on the input file name submitted)
