### PR TITLE
expose Content-Disposition header; and add extra param to name shp files in zip

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ function enableCors (req, res, next) {
   res.header('Access-Control-Allow-Origin', '*')
   res.header('Access-Control-Allow-Methods', 'POST')
   res.header('Access-Control-Allow-Headers', 'X-Requested-With')
+  res.header('Access-Control-Expose-Headers', 'Content-Disposition')
   next()
 }
 
@@ -72,6 +73,10 @@ exports.createServer = function (opts) {
     }
     else {
       ogr = ogr2ogr(JSON.parse(req.body.json))
+    }
+
+    if (req.body.fileName) {
+      ogr.options(['-nln', req.body.fileName])
     }
 
     if ('skipFailures' in req.body) {


### PR DESCRIPTION
Two updates:

One: add `res.header('Access-Control-Expose-Headers', 'Content-Disposition')` to `enableCors`. When using xhr the POST request will fail because the preflight and POST headers don't match if modifying the request headers of the xhr POST. This resolves the issue and relieves the need to set the `Access-Control-Expose-Headers` header of the POST.

Two: Add additional `fileName` check/param to `convertJson` to set the filenames of the .shp file and friends.