### PR TITLE
Implementing support for RFC7946 (Mapbox-compatible) GeoJSON

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,10 @@ exports.createServer = function(opts) {
       ogr.project(req.body.targetSrs, req.body.sourceSrs)
     }
 
+    if ('rfc7946' in req.body) {
+      ogr.options(['-lco', 'RFC7946=YES'])
+    }
+
     if ('skipFailures' in req.body) {
       ogr.skipfailures()
     }

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -45,7 +45,6 @@ html
                       label
                         input(name="rfc7946", type='checkbox')
                         | Create Mapbox-compatible file (RFC7946)
-                .form-group
                   .col-sm-9.col-sm-offset-3
                     .checkbox
                       label

--- a/views/layout.jade
+++ b/views/layout.jade
@@ -43,6 +43,12 @@ html
                   .col-sm-9.col-sm-offset-3
                     .checkbox
                       label
+                        input(name="rfc7946", type='checkbox')
+                        | Create Mapbox-compatible file (RFC7946)
+                .form-group
+                  .col-sm-9.col-sm-offset-3
+                    .checkbox
+                      label
                         input(name="skipFailures", type='checkbox')
                         | Skip failures
                   .col-sm-9.col-sm-offset-3


### PR DESCRIPTION
Resolve #66, allowing Ogre to create Mapbox-compliant GeoJSON. I wasn't able to make the checkbox disable the Target SRS field on check and reenable on uncheck, but perhaps someone else can show the way.