### PR TITLE
Fixed support to multiples formats

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const ogr2ogr = require('ogr2ogr')
 const fs = require('fs')
 const urlencoded = require('body-parser').urlencoded
 const join = require('path').join
+const tmpdir = require('os').tmpdir;
 
 function enableCors(req, res, next) {
   res.header('Access-Control-Allow-Origin', '*')
@@ -158,11 +159,11 @@ exports.createServer = function (opts) {
         case 'txt':
         case 'gxt':
         case 'gmt':
-          
+
           // Random string to prevent multiple request being overwritten
           let randomId = Math.random().toString(36).substring(7);
 
-          let tmpDestination = join(__dirname, `/tmp-${randomId}.${format}`)
+          let tmpDestination = join(tmpdir(), `/ogre-${randomId}.${format}`)
           await ogr.destination(tmpDestination).promise()
 
           let bufD = await fs.promises.readFile(tmpDestination, 'utf8')

--- a/index.js
+++ b/index.js
@@ -167,13 +167,10 @@ exports.createServer = function (opts) {
           await ogr.destination(tmpDestination).promise()
 
           let bufD = await fs.promises.readFile(tmpDestination, 'utf8')
-          let errUnlink = await fs.promises.unlink(tmpDestination)
+          await fs.promises.unlink(tmpDestination)
 
-          if (errUnlink) {
-            throw errUnlink
-          } else {
-            sendResponse(bufD)
-          }          
+          sendResponse(bufD)
+                    
           break;
 
         default:

--- a/index.js
+++ b/index.js
@@ -167,8 +167,13 @@ exports.createServer = function (opts) {
           await ogr.destination(tmpDestination).promise()
 
           let bufD = await fs.promises.readFile(tmpDestination, 'utf8')
-          fs.unlink(tmpDestination, noop)
-          sendResponse(bufD)
+          let errUnlink = await fs.promises.unlink(tmpDestination)
+
+          if (errUnlink) {
+            throw errUnlink
+          } else {
+            sendResponse(bufD)
+          }          
           break;
 
         default:

--- a/index.js
+++ b/index.js
@@ -112,7 +112,7 @@ exports.createServer = function (opts) {
     let json = safelyParseJson(req.body.json)
 
     if (req.body.json && !json)
-      return res.status(400).json({ error: true, msg: 'Invalid json provided' })
+      return res.status(400).json({error: true, msg: 'Invalid json provided'})
 
     let ogr
 

--- a/index.js
+++ b/index.js
@@ -122,8 +122,8 @@ exports.createServer = function (opts) {
       ogr = ogr2ogr(json)
     }
 
-    if (req.body.fileName) {
-      ogr.options(['-nln', req.body.fileName])
+    if (req.body.outputName) {
+      ogr.options(['-nln', req.body.outputName])
     }
 
     if ('skipFailures' in req.body) {

--- a/index.js
+++ b/index.js
@@ -159,7 +159,10 @@ exports.createServer = function (opts) {
         case 'gxt':
         case 'gmt':
           
-          let tmpDestination = join(__dirname, `/tmp.${format}`)
+          // Random string to prevent multiple request being overwritten
+          let randomId = Math.random().toString(36).substring(7);
+
+          let tmpDestination = join(__dirname, `/tmp-${randomId}.${format}`)
           await ogr.destination(tmpDestination).promise()
 
           let bufD = await fs.promises.readFile(tmpDestination, 'utf8')

--- a/index.js
+++ b/index.js
@@ -152,7 +152,7 @@ exports.createServer = function (opts) {
     try {
 
       switch (format) {
-        // This formats must use .destination
+        // These formats must use .destination
         case 'dxf':
         case 'dgn':
         case 'txt':
@@ -164,14 +164,13 @@ exports.createServer = function (opts) {
 
           let bufD = await fs.promises.readFile(tmpDestination, 'utf8')
           fs.unlink(tmpDestination, noop)
-
           sendResponse(bufD)
           break;
 
         default:
           let buf = await ogr.promise()
           sendResponse(buf)
-          break;
+          break;        
       }
 
     } catch (er) {

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ function safelyParseJson(json) {
   }
 }
 
-function noop() { }
+function noop() {}
 
 exports.createServer = function (opts) {
   if (!opts) opts = {}
@@ -49,12 +49,12 @@ exports.createServer = function (opts) {
     res.render('home')
   })
 
-  app.use(urlencoded({ extended: false, limit: 3000000 })) // 3mb
-  app.use(multiparty({ maxFilesSize: 100000000 })) // 100mb
+  app.use(urlencoded({extended: false, limit: 3000000})) // 3mb
+  app.use(multiparty({maxFilesSize: 100000000})) // 100mb
 
   app.post('/convert', enableCors, function (req, res, next) {
     if (!req.files.upload || !req.files.upload.name) {
-      res.status(400).json({ error: true, msg: 'No file provided' })
+      res.status(400).json({error: true, msg: 'No file provided'})
       return
     }
 
@@ -93,7 +93,7 @@ exports.createServer = function (opts) {
       if (isOgreFailureError(er)) {
         return res
           .status(400)
-          .json({ errors: er.message.replace('\n\n', '').split('\n') })
+          .json({errors: er.message.replace('\n\n', '').split('\n')})
       }
 
       if (er) return next(er)
@@ -107,7 +107,7 @@ exports.createServer = function (opts) {
 
   app.post('/convertJson', enableCors, async function (req, res, next) {
     if (!req.body.jsonUrl && !req.body.json)
-      return res.status(400).json({ error: true, msg: 'No json provided' })
+      return res.status(400).json({error: true, msg: 'No json provided'})
 
     let json = safelyParseJson(req.body.json)
 
@@ -186,7 +186,7 @@ exports.createServer = function (opts) {
   app.use(function (er, req, res, next) {
     console.error(er.stack)
     res.header('Content-Type', 'application/json')
-    res.status(500).json({ error: true, msg: er.message })
+    res.status(500).json({error: true, msg: er.message})
   })
 
   return app

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ function safelyParseJson(json) {
   }
 }
 
-function noop() {}
+function noop() { }
 
 exports.createServer = function (opts) {
   if (!opts) opts = {}
@@ -49,12 +49,12 @@ exports.createServer = function (opts) {
     res.render('home')
   })
 
-  app.use(urlencoded({extended: false, limit: 3000000})) // 3mb
-  app.use(multiparty({maxFilesSize: 100000000})) // 100mb
+  app.use(urlencoded({ extended: false, limit: 3000000 })) // 3mb
+  app.use(multiparty({ maxFilesSize: 100000000 })) // 100mb
 
   app.post('/convert', enableCors, function (req, res, next) {
     if (!req.files.upload || !req.files.upload.name) {
-      res.status(400).json({error: true, msg: 'No file provided'})
+      res.status(400).json({ error: true, msg: 'No file provided' })
       return
     }
 
@@ -93,7 +93,7 @@ exports.createServer = function (opts) {
       if (isOgreFailureError(er)) {
         return res
           .status(400)
-          .json({errors: er.message.replace('\n\n', '').split('\n')})
+          .json({ errors: er.message.replace('\n\n', '').split('\n') })
       }
 
       if (er) return next(er)
@@ -107,12 +107,12 @@ exports.createServer = function (opts) {
 
   app.post('/convertJson', enableCors, async function (req, res, next) {
     if (!req.body.jsonUrl && !req.body.json)
-      return res.status(400).json({error: true, msg: 'No json provided'})
+      return res.status(400).json({ error: true, msg: 'No json provided' })
 
     let json = safelyParseJson(req.body.json)
 
     if (req.body.json && !json)
-      return res.status(400).json({error: true, msg: 'Invalid json provided'})
+      return res.status(400).json({ error: true, msg: 'Invalid json provided' })
 
     let ogr
 
@@ -134,7 +134,7 @@ exports.createServer = function (opts) {
       ogr.timeout(opts.timeout)
     }
 
-    let format = req.body.format || 'shp'
+    let format = req.body.format.toLowerCase() || 'shp'
 
     ogr.format(format)
 
@@ -151,20 +151,27 @@ exports.createServer = function (opts) {
 
     try {
 
-      // dxf must be treated using .destination
-      if (format.toLowerCase() === 'dxf') {
+      switch (format) {
+        // This formats must use .destination
+        case 'dxf':
+        case 'dgn':
+        case 'txt':
+        case 'gxt':
+        case 'gmt':
+          
+          let tmpDestination = join(__dirname, `/tmp.${format}`)
+          await ogr.destination(tmpDestination).promise()
 
-        let tmpDestination = join(__dirname, '/tmp')
-        await ogr.destination(tmpDestination).promise()
+          let bufD = await fs.promises.readFile(tmpDestination, 'utf8')
+          fs.unlink(tmpDestination, noop)
 
-        let buf = await fs.promises.readFile(tmpDestination, 'utf8')
-        fs.unlink(tmpDestination, noop)
-        
-        sendResponse(buf)
+          sendResponse(bufD)
+          break;
 
-      } else {
-        let buf = await ogr.promise()
-        sendResponse(buf)
+        default:
+          let buf = await ogr.promise()
+          sendResponse(buf)
+          break;
       }
 
     } catch (er) {
@@ -180,7 +187,7 @@ exports.createServer = function (opts) {
   app.use(function (er, req, res, next) {
     console.error(er.stack)
     res.header('Content-Type', 'application/json')
-    res.status(500).json({error: true, msg: er.message})
+    res.status(500).json({ error: true, msg: er.message })
   })
 
   return app


### PR DESCRIPTION
DXF, DGN, TXT, GXT and GMT are now processed using the ogr.destination() method. When using pipes/stream the process fails with these formats.

Fixed incorrect parameter req.body.fileName. Renamed to req.body.outputName.