### PR TITLE
Add force utf-8 option

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,6 +130,10 @@ exports.createServer = function (opts) {
       ogr.skipfailures()
     }
 
+    if ('forceUTF8' in req.body) {
+      ogr.options(['-lco', 'ENCODING=UTF-8'])
+    }
+
     if (opts.timeout) {
       ogr.timeout(opts.timeout)
     }

--- a/views/home.pug
+++ b/views/home.pug
@@ -120,6 +120,7 @@ block body
       li <code>jsonUrl</code> - the URL for a remote GeoJSON file
       li <code>outputName</code> (optional) - the name for the resulting zip file
       li <code>skipFailures</code> (optional) - skip failures
+      li <code>forceUTF8</code> (optional) - force utf-8
       li <code>format</code> (optional) - File format supported by the <a href="https://github.com/wavded/ogr2ogr">ogr2ogr wrapper</a>
 
     h3 Where can I watch the project status, report issues, contribute, or fork the code?

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -91,6 +91,11 @@ html
                       label
                         input(name="skipFailures", type='checkbox')
                         | Skip failures
+                  .col-sm-9.col-sm-offset-3
+                    .checkbox
+                      label
+                        input(name="forceUTF8", type='checkbox')
+                        | Force UTF-8
                 .form-group
                   .col-sm-9.col-sm-offset-3
                     button.btn.btn-warning(name="convert") Convert to Shapefile


### PR DESCRIPTION
# Add force encoding utf-8 option for "Convert from GeoJSON"

For properties use key (unicode) like this example:
```json
{ "type": "FeatureCollection",
  "features": [{
    "type": "Feature",
    "geometry": { "type": "Point", "coordinates": [102.0, 0.5] },
    "properties": { "名字": "value0" }
  }]
}
```
The result from ogr2ogr can't output attribute information correctly:
<img width="714" alt="Ogr_58008b32173- Features Total 1, Fiitered 1, Selected O" src="https://user-images.githubusercontent.com/20501203/105795237-6efae880-5fc7-11eb-8d9d-d7151fc7cf05.png">

Considerin data similar to the above, I want to add an option to handle this situation. 
From this [post](https://www.mail-archive.com/gdal-dev@lists.osgeo.org/msg12322.html), I add this to force utf-8 encoding:
```javascript
if ('forceUTF8' in req.body) {
      ogr.options(['-lco', 'ENCODING=UTF-8'])
}
```

