### PR TITLE
Fix for #89 , bump connect-multiparty to support node 14.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['10', '12']
+        node: ['10', '12', '14']
     name: Node v${{ matrix.node }}
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "main": "./index.js",
   "dependencies": {
     "body-parser": "^1.9.2",
-    "connect-multiparty": "^2.0.0",
+    "connect-multiparty": "^2.2.0",
     "express": "^4.10.2",
     "ogr2ogr": "^2.0.0",
     "pug": "^3.0.0"


### PR DESCRIPTION
Found [this issue](https://github.com/expressjs/connect-multiparty/issues/29) that shows they had problems in connect-multiparty with Node 14. Bumped the package.json file to use their latest version, and added Node 14 to Github Actions tests
